### PR TITLE
Support for linking to a separate media-synchroniser implementation, …

### DIFF
--- a/bin/hbbtv.js
+++ b/bin/hbbtv.js
@@ -24,13 +24,20 @@ program.version(package.version)
     .allowUnknownOption(false)
     .option("-m, --mode <mode>", "select mode. It is either 'terminal' to start as HbbTV Terminal or 'cs' to start as Companion Screen", /^(terminal|cs)$/i)
     .option("-p, --port <port>", "specify the port number of the HbbTV Terminal or CS Launcher. e.g. 8080",parseInt)
+    .option("-i, --interdevsync-url <url>", "specify the URL of the inter-device synchronisation CSS-CII server. Applies to 'terminal' mode only. Optional.")
+    .option("-u, --useragent <ua-string>", "specify the user agent string to be advertised. Applies to 'terminal' mode only. Optional.")
 
 program.parse(process.argv);
 var port = program.port>0 && program.port || null;
 var mode = program.mode || null;
+var interDevSyncUrl = program["interdevsyncUrl"] || null;
+var userAgent = program["useragent"] || null;
+
 if(port){
     global.PORT = port;
     if(mode == "terminal"){
+        global.INTERDEVSYNC_URL = interDevSyncUrl;
+        global.USERAGENT = userAgent;
         require("./start-terminal.js");
     }
     else if(mode == "cs"){

--- a/bin/start-terminal.js
+++ b/bin/start-terminal.js
@@ -19,6 +19,8 @@
  *
  ******************************************************************************/
 var PORT = global.PORT;
+var INTERDEVSYNC_URL = global.INTERDEVSYNC_URL;
+var USERAGENT = global.USERAGENT;
 if(!PORT){
     console.log("variable 'global.PORT' is missing or not a valid port");
     process.exit(1);
@@ -37,6 +39,8 @@ var counter = 0;
 app.set("port",PORT);
 app.set("dial-prefix",DIAL_PREFIX);
 app.set("cs-manager-prefix", CS_MANAGER_PREFIX);
+app.set("inter-dev-sync-url", INTERDEVSYNC_URL);
+app.set("user-agent", USERAGENT);
 // The HTTP Server is used to in the HbbTVApp2AppServer and the HbbTVDialServer
 var httpServer = http.createServer(app);
 

--- a/lib/hbbtv-dial-server.js
+++ b/lib/hbbtv-dial-server.js
@@ -173,6 +173,14 @@ var HbbTVDialServer = function (expressApp, isCsLauncher) {
                     if(appName == "HbbTV"){
                         var hostname = this.hostname;
                         app.additionalData["hbbtv:X_HbbTV_App2AppURL"] = "ws://"+hostname+":"+port+"/remote/";
+                        var interDevSyncUrl = expressApp.get("inter-dev-sync-url");
+                        if (interDevSyncUrl != null) {
+                            app.additionalData["hbbtv:X_HbbTV_InterDevSyncURL"] = String(interDevSyncUrl);
+                        }
+                        var userAgent = expressApp.get("user-agent");
+                        if (userAgent != null) {
+                            app.additionalData["hbbtv:X_HbbTV_UserAgent"] = String(userAgent);
+                        }
                     }
                     return app;
                 }


### PR DESCRIPTION
…and for providing UserAgent info.

Hello, this pull-request adds a simple command line option to allow setting the URL of the inter-device synchronisation server (the value of the `<X_HbbTV_InterDevSyncURL>` XML element). This allows a separate implementation of the inter-device synchronisation server to be used in combination with this.

It also adds an option to allow the value of the `<X_HbbTV_UserAgent>` XML element to be specified.

For example:

> $ node hbbtv.js -m terminal -p 8201 -interdevsync-url ws://192.168.0.10:7681/cii -useragent "HbbTV/1.3.1 (;;;;;)"
