### PR TITLE
Add option to set arguments to opn call, used for launching apps in browser.

### DIFF
--- a/bin/hbbtv.js
+++ b/bin/hbbtv.js
@@ -26,15 +26,18 @@ program.version(package.version)
     .option("-p, --port <port>", "specify the port number of the HbbTV Terminal or CS Launcher. e.g. 8080",parseInt)
     .option("-i, --interdevsync-url <url>", "specify the URL of the inter-device synchronisation CSS-CII server. Applies to 'terminal' mode only. Optional.")
     .option("-u, --useragent <ua-string>", "specify the user agent string to be advertised. Applies to 'terminal' mode only. Optional.")
+    .option("-o, --opn-args <args>",  "specify the arguments to opn (used for launching apps), separated by | characters. e.g. firefox|-no-remote. Optional.")
 
 program.parse(process.argv);
 var port = program.port>0 && program.port || null;
 var mode = program.mode || null;
 var interDevSyncUrl = program["interdevsyncUrl"] || null;
 var userAgent = program["useragent"] || null;
+var opn_params = program["opnArgs"] ? program["opnArgs"].split('|') : undefined;
 
 if(port){
     global.PORT = port;
+    global.OPN_PARAMS = opn_params;
     if(mode == "terminal"){
         global.INTERDEVSYNC_URL = interDevSyncUrl;
         global.USERAGENT = userAgent;

--- a/bin/start-terminal.js
+++ b/bin/start-terminal.js
@@ -21,6 +21,7 @@
 var PORT = global.PORT;
 var INTERDEVSYNC_URL = global.INTERDEVSYNC_URL;
 var USERAGENT = global.USERAGENT;
+var OPN_PARAMS = global.OPN_PARAMS;
 if(!PORT){
     console.log("variable 'global.PORT' is missing or not a valid port");
     process.exit(1);
@@ -41,6 +42,7 @@ app.set("dial-prefix",DIAL_PREFIX);
 app.set("cs-manager-prefix", CS_MANAGER_PREFIX);
 app.set("inter-dev-sync-url", INTERDEVSYNC_URL);
 app.set("user-agent", USERAGENT);
+app.set("opn-params", OPN_PARAMS);
 // The HTTP Server is used to in the HbbTVApp2AppServer and the HbbTVDialServer
 var httpServer = http.createServer(app);
 

--- a/lib/hbbtv-dial-server.js
+++ b/lib/hbbtv-dial-server.js
@@ -30,6 +30,7 @@ var HbbTVDialServer = function (expressApp, isCsLauncher) {
     var port = expressApp.get("port") || 80;
     var prefix = expressApp.get("dial-prefix") || "";
     var csManagerPrefix = expressApp.get("cs.manager-prefix") || "";
+    var opnParams = expressApp.get("opn-params");
     isCsLauncher = (isCsLauncher == true);
     var apps = {
         "YouTube": {
@@ -69,7 +70,7 @@ var HbbTVDialServer = function (expressApp, isCsLauncher) {
 
     var openUrl = function (url) {
         try{
-            opn(url);
+            opn(url, opnParams);
         }
         catch(err){
             console.error("Error on open URL", err.message);


### PR DESCRIPTION
This adds a command line option to specify options used in the call to opn, used to launch apps in the browser.
This is useful when apps need to be launched in a browser instance other than the system default, or with some debugging or other flags.
