### PR TITLE
Update link to specification.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -421,5 +421,5 @@ Contact
 
 ![Fraunhofer FOKUS](https://famalytics.fokus.fraunhofer.de/piwik.php?idsite=19&rec=1&action_name=node-hbbtv-readme)
 
-[hbbtv20spec]: http://hbbtv.org/pages/about_hbbtv/HbbTV_specification_2_0.pdf
+[hbbtv20spec]: http://www.hbbtv.org/wp-content/uploads/2015/07/HbbTV-SPEC20-00023-001-HbbTV_2.0.1_specification_for_publication_clean.pdf
 [dial-reg]: http://www.dial-multiscreen.org/dial-registry/namespace-database#TOC-Registered-Names


### PR DESCRIPTION
This new URL fixes a 404 in the current URL. It is the 2.0.1 spec, as opposed to the 2.0.0 spec.
