### PR TITLE
Allow overriding of user-visible terminal name

### DIFF
--- a/bin/hbbtv.js
+++ b/bin/hbbtv.js
@@ -27,6 +27,7 @@ program.version(package.version)
     .option("-i, --interdevsync-url <url>", "specify the URL of the inter-device synchronisation CSS-CII server. Applies to 'terminal' mode only. Optional.")
     .option("-u, --useragent <ua-string>", "specify the user agent string to be advertised. Applies to 'terminal' mode only. Optional.")
     .option("-o, --opn-args <args>",  "specify the arguments to opn (used for launching apps), separated by | characters. e.g. firefox|-no-remote. Optional.")
+    .option("-f, --friendly-name <name>",  "specify the device name to be advertised (overriding system hostname). Applies to 'terminal' mode only. Optional.")
 
 program.parse(process.argv);
 var port = program.port>0 && program.port || null;
@@ -34,6 +35,7 @@ var mode = program.mode || null;
 var interDevSyncUrl = program["interdevsyncUrl"] || null;
 var userAgent = program["useragent"] || null;
 var opn_params = program["opnArgs"] ? program["opnArgs"].split('|') : undefined;
+var friendlyName = program["friendlyName"] || null;
 
 if(port){
     global.PORT = port;
@@ -41,6 +43,7 @@ if(port){
     if(mode == "terminal"){
         global.INTERDEVSYNC_URL = interDevSyncUrl;
         global.USERAGENT = userAgent;
+        global.FRIENDLY_NAME = friendlyName;
         require("./start-terminal.js");
     }
     else if(mode == "cs"){

--- a/lib/hbbtv-dial-server.js
+++ b/lib/hbbtv-dial-server.js
@@ -27,6 +27,7 @@ var HbbTVDialServer = function (expressApp, isCsLauncher) {
     var self = this;
     var MANUFACTURER = "Fraunhofer FOKUS";
     var MODEL_NAME = "HbbTV 2.0 Node.js Companion Screen Feature Emulator";
+    var FRIENDLY_NAME = global.FRIENDLY_NAME; // May be null, in which case the hostname is used.
     var port = expressApp.get("port") || 80;
     var prefix = expressApp.get("dial-prefix") || "";
     var csManagerPrefix = expressApp.get("cs.manager-prefix") || "";
@@ -167,6 +168,7 @@ var HbbTVDialServer = function (expressApp, isCsLauncher) {
         port: port,
         manufacturer: MANUFACTURER,
         modelName: MODEL_NAME,
+        friendlyName : FRIENDLY_NAME,
         corsAllowOrigins: true,
         delegate: {
             getApp: function(appName){


### PR DESCRIPTION
Added an option -f/--friendly-name to allow overriding the friendly name transmitted to the companions over DIAL.

This is needed when running the terminal on android (at least when using termux), because the system hostname (which is picked up by peer-dial, by default) is the rather useless "localhost". 
